### PR TITLE
[Input::Mouse]Pressed系メソッドの挙動を修正

### DIFF
--- a/Project/Code/Input/Mouse.cpp
+++ b/Project/Code/Input/Mouse.cpp
@@ -50,7 +50,7 @@ namespace Input {
 		if (pressedDuration > 0) pressedDuration++;
 
 		auto range = [](const Vector2<int> m) ->bool {
-			return 0 <= m.x && m.x < gWindowSize.x && 0 <= m.y && m.y < gWindowSize.y;
+			return true;
 		};
 
 		int downNum = get().getButtonChangeCount(range, buttonType, MOUSE_INPUT_LOG_DOWN);

--- a/Project/Code/Input/Mouse.h
+++ b/Project/Code/Input/Mouse.h
@@ -87,8 +87,12 @@ namespace Input {
 			if (mMouseL.clicked) mMouseL.clicked = !eraseFlag;
 			return isMouseOver(p1, p2) && mMouseL.clicked;
 		}
+		// マウス左ボタンが押されているかどうかを返す
+		bool leftPressed() const {
+			return mMouseL.pressed;
+		}
 		// 左上座標 p1 、右下座標 p2 の矩形範囲内でマウス左ボタンが押されているかどうかを返す
-		bool leftPressed(Vector2<int> p1 = { 0, 0 }, Vector2<int> p2 = gWindowSize) const {
+		bool leftPressed(Vector2<int> p1, Vector2<int> p2) const {
 			return isMouseOver(p1, p2) && mMouseL.pressed;
 		}
 		// 左上座標 p1 、右下座標 p2 の矩形範囲内でマウス左ボタンが離されたかどうかを返す
@@ -102,8 +106,12 @@ namespace Input {
 			if (mMouseR.clicked) mMouseR.clicked = !eraseFlag;
 			return isMouseOver(p1, p2) && mMouseR.clicked;
 		}
+		// マウス右ボタンが押されているかどうかを返す
+		bool rightPressed() const {
+			return mMouseR.pressed;
+		}
 		// 左上座標 p1 、右下座標 p2 の矩形範囲内でマウス右ボタンが押されているかどうかを返す
-		bool rightPressed(Vector2<int> p1 = { 0, 0 }, Vector2<int> p2 = gWindowSize) const {
+		bool rightPressed(Vector2<int> p1, Vector2<int> p2) const {
 			return isMouseOver(p1, p2) && mMouseR.pressed;
 		}
 		// 左上座標 p1 、右下座標 p2 の矩形範囲内でマウス右ボタンが離されたかどうかを返す

--- a/Project/Code/Input/Mouse.h
+++ b/Project/Code/Input/Mouse.h
@@ -84,8 +84,11 @@ namespace Input {
 
 		// 左上座標 p1 、右下座標 p2 の矩形範囲内でマウス左ボタンがクリックされたかどうかを返す
 		bool leftClicked(Vector2<int> p1 = { 0, 0 }, Vector2<int> p2 = gWindowSize, bool eraseFlag = true) const {
-			if (mMouseL.clicked) mMouseL.clicked = !eraseFlag;
-			return isMouseOver(p1, p2) && mMouseL.clicked;
+			if (isMouseOver(p1, p2) && mMouseL.clicked) {
+				mMouseL.clicked = !eraseFlag;
+				return true;
+			}
+			return false;
 		}
 		// マウス左ボタンが押されているかどうかを返す
 		bool leftPressed() const {
@@ -97,14 +100,20 @@ namespace Input {
 		}
 		// 左上座標 p1 、右下座標 p2 の矩形範囲内でマウス左ボタンが離されたかどうかを返す
 		bool leftReleased(Vector2<int> p1 = { 0, 0 }, Vector2<int> p2 = gWindowSize, bool eraseFlag = true) const {
-			if (mMouseL.released) mMouseL.released = !eraseFlag;
-			return isMouseOver(p1, p2) && mMouseL.released;
+			if (isMouseOver(p1, p2) && mMouseL.released) {
+				mMouseL.released = !eraseFlag;
+				return true;
+			}
+			return false;
 		}
 
 		// 左上座標 p1 、右下座標 p2 の矩形範囲内でマウス右ボタンがクリックされたかどうかを返す
 		bool rightClicked(Vector2<int> p1 = { 0, 0 }, Vector2<int> p2 = gWindowSize, bool eraseFlag = true) const {
-			if (mMouseR.clicked) mMouseR.clicked = !eraseFlag;
-			return isMouseOver(p1, p2) && mMouseR.clicked;
+			if (isMouseOver(p1, p2) && mMouseR.clicked) {
+				mMouseR.clicked = !eraseFlag;
+				return true;
+			}
+			return false;
 		}
 		// マウス右ボタンが押されているかどうかを返す
 		bool rightPressed() const {
@@ -116,8 +125,11 @@ namespace Input {
 		}
 		// 左上座標 p1 、右下座標 p2 の矩形範囲内でマウス右ボタンが離されたかどうかを返す
 		bool rightReleased(Vector2<int> p1 = { 0, 0 }, Vector2<int> p2 = gWindowSize, bool eraseFlag = true) const {
-			if (mMouseR.clicked) mMouseR.released = !eraseFlag;
-			return isMouseOver(p1, p2) && mMouseR.released;
+			if (isMouseOver(p1, p2) && mMouseR.clicked) {
+				mMouseR.released = !eraseFlag;
+				return true;
+			}
+			return false;
 		}
 
 		// マウス左ボタンが何フレーム押されているかを返す


### PR DESCRIPTION
ButtonStateのupdateでは座標を指定しないよう変更
leftPressed、rightPressedをオーバーロードし、座標指定Verと指定しないVerの両方を使えるように修正

また、Clicked、Released系関数の挙動に問題があったため一部修正しました。